### PR TITLE
Remove Grafana TLS Auth = true

### DIFF
--- a/docker/grafana/datasource.yaml
+++ b/docker/grafana/datasource.yaml
@@ -38,8 +38,8 @@ datasources:
   # <map> fields that will be converted to json and stored in json_data
   jsonData:
      graphiteVersion: "1.1"
-     tlsAuth: true
-     tlsAuthWithCACert: true
+     tlsAuth: false
+     tlsAuthWithCACert: false
   # <string> json object of data that will be encrypted.
   secureJsonData:
     tlsCACert: "..."


### PR DESCRIPTION
Hi,

by running the docker-compose as is, I got an error connecting to the datasource.

Setting 
```
     tlsAuth: false
     tlsAuthWithCACert: false
```

fixed this, so the project works out of the box.